### PR TITLE
fix: Set correct Vite base path for custom domain

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/about/',
+  base: '/',
   plugins: [react()],
 })


### PR DESCRIPTION
This commit corrects the `base` path in the `vite.config.js` file from `'/about/'` to `'/'`.

When a custom domain is used with GitHub Pages, the site is served from the root of the domain, not from a sub-path named after the repository. This change ensures that the application's assets are loaded correctly from the root of the custom domain.