### PR TITLE
This commit adds the `cname` property to the `peaceiris/actions-gh-pa…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          cname: aspeedsoftware.top


### PR DESCRIPTION
…ges` step in the `.github/workflows/deploy.yml` file.

This is necessary to ensure that the custom domain (`aspeedsoftware.top`) is correctly configured when deploying to GitHub Pages. Without this, GitHub Pages does not know to associate the deployed content with the custom domain, resulting in a 404 error.